### PR TITLE
Load actual contents instead of sample course.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,7 +72,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<List<CourseWithMetadata>> loadContents() async {
     final tocJson = await loadJsonAsset("contents/toc.json");
     final tocModel = Toc.fromJson(tocJson);
-    final samples = await tocModel.getSamples();
+    final samples = await tocModel.getArticles();
     return samples;
   }
 

--- a/lib/tabs/learn_tab.dart
+++ b/lib/tabs/learn_tab.dart
@@ -177,7 +177,7 @@ class LearnTab extends StatelessWidget {
             buttonInfo: CourseInformation(e.course, 0.2, Colors.blue)))
         .toList();
 
-    return Column(
+    return ListView(
       children: <Widget>[
         Text(
           'In Progress',


### PR DESCRIPTION
- Actual contents are growing nicely, so switched the loaded contents from the sample course to actual ones.